### PR TITLE
Fix React context usage

### DIFF
--- a/Hammurabi/hammurabi-ui/src/newViewport/components/Overlays/Circle.tsx
+++ b/Hammurabi/hammurabi-ui/src/newViewport/components/Overlays/Circle.tsx
@@ -1,4 +1,4 @@
-import { use, memo } from "react";
+import { useContext, memo } from "react";
 import { applyToPoint } from "transformation-matrix";
 import { ViewportContext } from "../FrameViewport";
 
@@ -22,7 +22,7 @@ export const Circle: React.FC<Props> = memo(function Circle(props) {
     ...rest
   } = props;
 
-  const { matrix, zoomPanMatrix } = use(ViewportContext);
+  const { matrix, zoomPanMatrix } = useContext(ViewportContext);
   const imagePoint = { x: +cx, y: +cy };
   const screenPoint = applyToPoint(matrix, imagePoint);
   const radius = fixedSize ? r : (r as number) * zoomPanMatrix.a;

--- a/Hammurabi/hammurabi-ui/src/newViewport/components/Overlays/Image.tsx
+++ b/Hammurabi/hammurabi-ui/src/newViewport/components/Overlays/Image.tsx
@@ -1,4 +1,4 @@
-import { use, memo } from "react";
+import { useContext, memo } from "react";
 import { applyToPoint } from "transformation-matrix";
 import { ViewportContext } from "../FrameViewport";
 
@@ -19,7 +19,7 @@ export const Image: React.FC<Props> = memo(function Image(props) {
     ...rest
   } = props;
 
-  const { matrix } = use(ViewportContext);
+  const { matrix } = useContext(ViewportContext);
   const leftTop = { x: +x, y: +y };
   const rightBottom = { x: +x + +width, y: +y + +height };
   const leftTopPoint = applyToPoint(matrix, leftTop);

--- a/Hammurabi/hammurabi-ui/src/newViewport/components/Overlays/InputField.tsx
+++ b/Hammurabi/hammurabi-ui/src/newViewport/components/Overlays/InputField.tsx
@@ -1,4 +1,4 @@
-import { use, memo } from "react";
+import { useContext, memo } from "react";
 import { applyToPoint } from "transformation-matrix";
 import { ViewportContext } from "../FrameViewport";
 
@@ -20,7 +20,7 @@ export const InputField: React.FC<Props> = memo(function InputField(props) {
     transformY = 0,
   } = props;
 
-  const { matrix } = use(ViewportContext);
+  const { matrix } = useContext(ViewportContext);
   const imagePoint = { x: +x, y: +y };
   const screenPoint = applyToPoint(matrix, imagePoint);
 

--- a/Hammurabi/hammurabi-ui/src/newViewport/components/Overlays/Polyline.tsx
+++ b/Hammurabi/hammurabi-ui/src/newViewport/components/Overlays/Polyline.tsx
@@ -1,4 +1,4 @@
-import { use, memo } from "react";
+import { useContext, memo } from "react";
 import { applyToPoint } from "transformation-matrix";
 import { ViewportContext } from "../FrameViewport";
 
@@ -19,7 +19,7 @@ export const Polyline: React.FC<Props> = memo(function Polyline(props) {
     transformY = 0,
   } = props;
 
-  const { matrix } = use(ViewportContext);
+  const { matrix } = useContext(ViewportContext);
   const screenPoints = (points ?? "")
     .split(" ")
     .reduce((prv, cur) => {

--- a/Hammurabi/hammurabi-ui/src/newViewport/components/Overlays/Text.tsx
+++ b/Hammurabi/hammurabi-ui/src/newViewport/components/Overlays/Text.tsx
@@ -1,4 +1,4 @@
-import { use, memo } from "react";
+import { useContext, memo } from "react";
 import { applyToPoint } from "transformation-matrix";
 import { ViewportContext } from "../FrameViewport";
 
@@ -18,7 +18,7 @@ export const Text: React.FC<Props> = memo(function Text(props) {
     transformY = 0,
   } = props;
 
-  const { matrix } = use(ViewportContext);
+  const { matrix } = useContext(ViewportContext);
   const imagePoint = { x: +x, y: +y };
   const screenPoint = applyToPoint(matrix, imagePoint);
 

--- a/Hammurabi/hammurabi-ui/src/newViewport/hooks/useImageCoordinates.ts
+++ b/Hammurabi/hammurabi-ui/src/newViewport/hooks/useImageCoordinates.ts
@@ -1,4 +1,4 @@
-import { RefObject, use, useRef, useCallback } from "react";
+import { RefObject, useContext, useRef, useCallback } from "react";
 import { applyToPoint, inverse } from "transformation-matrix";
 import { ViewportContext } from "../components/FrameViewport";
 import { Point, Size } from "../types";
@@ -17,7 +17,7 @@ export type ToImage = (
  * that converts a mouse (or pointer) event to an image position.
  */
 const useImageCoordinates: UseImageCoordinates = (overlay) => {
-  const context = use(ViewportContext);
+  const context = useContext(ViewportContext);
   const contextRef = useRef(context);
   contextRef.current = context;
 


### PR DESCRIPTION
## Summary
- use `useContext` instead of experimental `use` API in viewport overlays and hooks

## Testing
- `npm test -- --watchAll=false` *(fails: Jest encountered unexpected token)*

------
https://chatgpt.com/codex/tasks/task_e_683ff9feaf14832daab3eeb3fabe7d0f