### PR TITLE
Fix import in ReactEcs CDK test

### DIFF
--- a/hammurabi-cdk/tests/unit/test_react_eks_cdk_stack.py
+++ b/hammurabi-cdk/tests/unit/test_react_eks_cdk_stack.py
@@ -1,13 +1,13 @@
 import aws_cdk as core
 import aws_cdk.assertions as assertions
 
-from react_eks_cdk.react_eks_cdk_stack import ReactEksCdkStack
+from react_ecs_cdk.react_ecs_cdk_stack import ReactEcsCdkStack
 
 # example tests. To run these tests, uncomment this file along with the example
 # resource in react_eks_cdk/react_eks_cdk_stack.py
 def test_sqs_queue_created():
     app = core.App()
-    stack = ReactEksCdkStack(app, "react-eks-cdk")
+    stack = ReactEcsCdkStack(app, "react-eks-cdk")
     template = assertions.Template.from_stack(stack)
 
 #     template.has_resource_properties("AWS::SQS::Queue", {


### PR DESCRIPTION
## Summary
- point the unit test to `ReactEcsCdkStack`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'aws_cdk')*

------
https://chatgpt.com/codex/tasks/task_e_684001833608832daad19c6aa7987cb1