### PR TITLE
Wrap App in AuthProvider for tests

### DIFF
--- a/Hammurabi/hammurabi-ui/src/App.test.tsx
+++ b/Hammurabi/hammurabi-ui/src/App.test.tsx
@@ -1,11 +1,24 @@
 // src/App.test.tsx
 import React from 'react';
 import { render, screen } from '@testing-library/react';
+import { AuthProvider } from 'react-oidc-context';
 import App from './App';
+
+const authConfig = {
+  authority: '',
+  client_id: '',
+  redirect_uri: '',
+  response_type: 'code',
+  scope: '',
+};
 
 // Simple test to ensure the component renders without routing/authentication
 test('renders basic UI', () => {
-  render(<App />);
+  render(
+    <AuthProvider {...authConfig}>
+      <App />
+    </AuthProvider>
+  );
 
   // Look for any static text in your App component
   // For example, we're looking for "Selection Page" or anything static


### PR DESCRIPTION
## Summary
- update unit test to use `AuthProvider`

## Testing
- `npm test --silent` *(fails: craco not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840016efc08832d9493925f25b0a8ed