### PR TITLE
Add setup script for local environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,16 @@ pip install -r requirements.txt
 cdk deploy ReactCdkCompleteStack
 ```
 
+### Quick setup
+
+Run `setup_env.sh` from the repository root to prepare both the CDK and UI
+environments. The script creates a Python virtual environment, installs CDK
+dependencies and fetches Node packages for the React front‑end.
+
+```bash
+./setup_env.sh
+```
+
 ## CI/CD
 
 `.github/workflows/ci.yml` builds the UI Docker image, pushes it to ECR, deploys the CDK stack and performs a blue/green ECS deployment through CodeDeploy. Google OAuth secrets are injected during the workflow.

--- a/setup_env.sh
+++ b/setup_env.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+# Setup script for Hammurabi workspace
+set -e
+
+# Determine script dir
+ROOT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+# ------ Setup Python environment for hammurabi-cdk ------
+cd "$ROOT_DIR/hammurabi-cdk"
+
+# Create virtual environment if it does not exist
+if [ ! -d ".venv" ]; then
+    python3 -m venv .venv
+fi
+
+source .venv/bin/activate
+pip install --upgrade pip
+pip install -r requirements.txt
+if [ -f requirements-dev.txt ]; then
+    pip install -r requirements-dev.txt
+fi
+
+deactivate
+
+# ------ Setup Node environment for hammurabi-ui ------
+cd "$ROOT_DIR/Hammurabi/hammurabi-ui"
+
+# Install node modules
+if [ -f package-lock.json ]; then
+    npm ci --legacy-peer-deps
+else
+    npm install
+fi
+
+# Generate env-config.js from template
+node scripts/generate-env.js
+
+echo "✅ Environment setup complete."


### PR DESCRIPTION
## Summary
- add `setup_env.sh` script to bootstrap the CDK and React UI
- document quick setup instructions in `README.md`

## Testing
- `pytest` in `hammurabi-cdk`
- `npm install` in `Hammurabi/hammurabi-ui`


------
https://chatgpt.com/codex/tasks/task_e_684005cbc04c832d936b541866f72608