### PR TITLE
Set sidebar height to viewport

### DIFF
--- a/Hammurabi/hammurabi-ui/src/schema/components/Sidebar.schema.json
+++ b/Hammurabi/hammurabi-ui/src/schema/components/Sidebar.schema.json
@@ -2,12 +2,12 @@
   "variants": {
     "desktop": {
       "width": 300,
-      "height": "calc(100vh - 60px - 40px)",
+      "height": "100vh",
       "collapsible": true
     },
     "tablet": {
       "width": 250,
-      "height": "calc(100vh - 60px - 40px)",
+      "height": "100vh",
       "collapsible": true
     },
     "mobile": {


### PR DESCRIPTION
## Summary
- make sidebar use the full viewport height

## Testing
- `CI=true npm test --silent` *(fails: Jest encountered an unexpected token)*

------
https://chatgpt.com/codex/tasks/task_e_684012e47588832dbe77c3a1b501bd09