### PR TITLE
[Hammurabi] fix front-end tests

### DIFF
--- a/Hammurabi/hammurabi-ui/package.json
+++ b/Hammurabi/hammurabi-ui/package.json
@@ -34,7 +34,7 @@
     "prebuild": "node scripts/generate-env.js",
     "start": "craco start",
     "build": "craco build",
-    "test": "vitest run",
+    "test": "node scripts/run-tests.js",
     "eject": "react-scripts eject",
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build"

--- a/Hammurabi/hammurabi-ui/scripts/run-tests.js
+++ b/Hammurabi/hammurabi-ui/scripts/run-tests.js
@@ -1,0 +1,7 @@
+const { spawnSync } = require('child_process');
+
+// Filter out unsupported -w=0 flag passed by CI script
+const args = process.argv.slice(2).filter(arg => arg !== '-w=0');
+
+const result = spawnSync('npx', ['vitest', 'run', '--watch=false', ...args], { stdio: 'inherit' });
+process.exit(result.status);


### PR DESCRIPTION
## Summary
- add wrapper script for Vitest to ignore `-w=0`
- update package.json to use the wrapper script

## Testing
- `CI=true npm test -- -w=0`
- `source .venv/bin/activate && pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684052fa53e4832d9a5e23be42708e1f